### PR TITLE
Check if x11_dpy is initialized

### DIFF
--- a/src/vdpau_driver.c
+++ b/src/vdpau_driver.c
@@ -184,6 +184,11 @@ vdpau_common_Terminate(vdpau_driver_data_t *driver_data)
 static VAStatus
 vdpau_common_Initialize(vdpau_driver_data_t *driver_data)
 {
+    if (!driver_data->x11_dpy) {
+        /* vaGetDisplayDRM() doesn't fill ->x11_dpy */
+        return VA_STATUS_ERROR_UNKNOWN;
+    }
+
     /* Create a dedicated X11 display for VDPAU purposes */
     const char * const x11_dpy_name = XDisplayString(driver_data->x11_dpy);
     driver_data->vdp_dpy = XOpenDisplay(x11_dpy_name);


### PR DESCRIPTION
vdpau-va-driver was created a long ago. Since then, libva have introduced a number of new ways to create a VA display handle.
It's now possible to use `vaGetDisplayDRM()`. It works on X11 environments too, but it keeps `x11_dpy` field `NULL`, which is not expected by the code in vdpau-va-driver. As VDPAU currently is X11-only, the only acceptable solution is to return error if `x11_dpy` is `NULL`.